### PR TITLE
Remove KCEF from unsupported containers

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -173,7 +173,7 @@ jobs:
         if: inputs.do_upload
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64/v8,linux/ppc64le,linux/s390x,linux/riscv64
+          platforms: linux/amd64,linux/arm64/v8
           push: true
           build-args: |
             BUILD_DATE=${{ steps.get_latest_release_metadata.outputs.build_date }}
@@ -181,6 +181,30 @@ jobs:
             TACHIDESK_RELEASE_DOWNLOAD_URL=${{ steps.get_latest_release_metadata.outputs.release_url }}
             TACHIDESK_FILENAME=${{ steps.get_latest_release_metadata.outputs.release_filename }}
             TACHIDESK_DOCKER_GIT_COMMIT=${{ steps.get_latest_release_metadata.outputs.tachidesk_docker_git_commit }}
+          tags: |
+            ${{ inputs.tachidesk_release_type == 'stable' && 'ghcr.io/suwayomi/tachidesk:latest' || '' }}
+            ghcr.io/suwayomi/tachidesk:${{ inputs.tachidesk_release_type }}
+            ghcr.io/suwayomi/tachidesk:${{ steps.get_latest_release_metadata.outputs.release_tag }}
+            ${{ inputs.tachidesk_release_type == 'stable' && 'ghcr.io/suwayomi/suwayomi-server:latest' || '' }}
+            ghcr.io/suwayomi/suwayomi-server:${{ inputs.tachidesk_release_type }}
+            ghcr.io/suwayomi/suwayomi-server:${{ steps.get_latest_release_metadata.outputs.release_tag }}
+
+      # And also those that aren't supported by KCEF
+      # the build arg TACHIDESK_KCEF will simply not install the dependencies, so runtime will fail to load libs
+      # but everything else will still work
+      - name: Push container image to registry
+        if: inputs.do_upload
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/ppc64le,linux/s390x,linux/riscv64
+          push: true
+          build-args: |
+            BUILD_DATE=${{ steps.get_latest_release_metadata.outputs.build_date }}
+            TACHIDESK_RELEASE_TAG=${{ steps.get_latest_release_metadata.outputs.release_tag }}
+            TACHIDESK_RELEASE_DOWNLOAD_URL=${{ steps.get_latest_release_metadata.outputs.release_url }}
+            TACHIDESK_FILENAME=${{ steps.get_latest_release_metadata.outputs.release_filename }}
+            TACHIDESK_DOCKER_GIT_COMMIT=${{ steps.get_latest_release_metadata.outputs.tachidesk_docker_git_commit }}
+            TACHIDESK_KCEF=n
           tags: |
             ${{ inputs.tachidesk_release_type == 'stable' && 'ghcr.io/suwayomi/tachidesk:latest' || '' }}
             ghcr.io/suwayomi/tachidesk:${{ inputs.tachidesk_release_type }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ARG TACHIDESK_RELEASE_TAG
 ARG TACHIDESK_FILENAME
 ARG TACHIDESK_RELEASE_DOWNLOAD_URL
 ARG TACHIDESK_DOCKER_GIT_COMMIT
+ARG TACHIDESK_KCEF=y # y or n
 
 LABEL maintainer="suwayomi" \
       org.opencontainers.image.title="Suwayomi Docker" \
@@ -34,12 +35,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # install CEF dependencies
-RUN apt-get update && \
-    apt-get -y install --no-install-recommends -y libxss1 libxext6 libxrender1 libxcomposite1 libxdamage1 libxkbcommon0 libxtst6 \
-        libjogl2-jni libgluegen2-jni libglib2.0-0t64 libnss3 libdbus-1-3 libpango-1.0-0 libcairo2 libasound2t64 \
-        libatk-bridge2.0-0t64 libcups2t64 libdrm2 libgbm1 xvfb && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+# Ubuntu exposes libgluegen_rt.so as libgluegen2_rt.so for some reason, so rename it
+# JCEF (or Java?) also does not search /usr/lib/jni, so copy them over into one it will search
+RUN if [ "$TACHIDESK_KCEF" = "y" ]; then \
+      apt-get update && \
+      apt-get -y install --no-install-recommends -y libxss1 libxext6 libxrender1 libxcomposite1 libxdamage1 libxkbcommon0 libxtst6 \
+          libjogl2-jni libgluegen2-jni libglib2.0-0t64 libnss3 libdbus-1-3 libpango-1.0-0 libcairo2 libasound2t64 \
+          libatk-bridge2.0-0t64 libcups2t64 libdrm2 libgbm1 xvfb && \
+      apt-get clean && \
+      rm -rf /var/lib/apt/lists/* || exit 1; \
+    fi
 
 # Create a user to run as
 RUN userdel -r ubuntu
@@ -60,16 +65,19 @@ COPY scripts/startup_script.sh /home/suwayomi/startup_script.sh
 RUN chown -R suwayomi:suwayomi /home/suwayomi && \
     chmod 777 -R /home/suwayomi
 
-# must be created by root
-RUN mkdir /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix
+# .X11-unix must be created by root
+# Ubuntu exposes libgluegen_rt.so as libgluegen2_rt.so for some reason, so rename it
+# JCEF (or Java?) also does not search /usr/lib/jni, so copy them over into one it will search
+RUN if [ "$TACHIDESK_KCEF" = "y" ]; then \
+      mkdir /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix && \
+      cp /usr/lib/jni/libgluegen2_rt.so libgluegen_rt.so && \
+      cp /usr/lib/jni/*.so ./; \
+    fi
 
 USER suwayomi
 EXPOSE 4567
+ENV TACHIDESK_KCEF=$TACHIDESK_KCEF
 
-# Ubuntu exposes libgluegen_rt.so as libgluegen2_rt.so for some reason, so rename it
-# JCEF (or Java?) also does not search /usr/lib/jni, so copy them over into one it will search
-RUN cp /usr/lib/jni/libgluegen2_rt.so libgluegen_rt.so && \
-    cp /usr/lib/jni/*.so ./
 
 CMD ["/home/suwayomi/startup_script.sh"]
 

--- a/scripts/startup_script.sh
+++ b/scripts/startup_script.sh
@@ -89,6 +89,10 @@ sed -i -r "s/server.opdsShowOnlyUnreadChapters = ([0-9]+|[a-zA-Z]+)( #)?/server.
 sed -i -r "s/server.opdsShowOnlyDownloadedChapters = ([0-9]+|[a-zA-Z]+)( #)?/server.opdsShowOnlyDownloadedChapters = ${OPDS_SHOW_ONLY_DOWNLOADED_CHAPTERS:-\1} #/" /home/suwayomi/.local/share/Tachidesk/server.conf
 sed -i -r "s/server.opdsChapterSortOrder = \"(.*?)\"( #)?/server.opdsChapterSortOrder = \"${OPDS_CHAPTER_SORT_ORDER:-\1}\" #/" /home/suwayomi/.local/share/Tachidesk/server.conf
 
-Xvfb :0 -screen 0 800x680x24 -nolisten tcp >/dev/null 2>&1 &
-export DISPLAY=:0
+if [ "$TACHIDESK_KCEF" = "" ] || [ "$TACHIDESK_KCEF" = "y" ]; then
+  Xvfb :0 -screen 0 800x680x24 -nolisten tcp >/dev/null 2>&1 &
+  export DISPLAY=:0
+else
+  echo "Suwayomi built without KCEF support, not starting Xvfb"
+fi
 exec java -Duser.home=/home/suwayomi -jar "/home/suwayomi/startup/tachidesk_latest.jar";


### PR DESCRIPTION
This introduces a new build arg TACHIDESK_KCEF which can be y or n and based on that runtime dependencies for KCEF/JCEF/CEF are installed or not.

In a container without this, startup might look like this:

```
17:43:37.703 [DefaultDispatcher-worker-9] INFO suwayomi.tachidesk.server.ServerSetup -- Socks Proxy changed - enabled=false address=: , username=, password=[REDACTED]
17:43:37.798 [main] INFO suwayomi.tachidesk.server.util.WebInterfaceManager setupWebUI(flavor= WebUI, servedFlavor= WebUI) -- found webUI files - version= r2467
17:43:37.798 [main] INFO suwayomi.tachidesk.server.util.WebInterfaceManager isLocalWebUIValid(flavor= WebUI, path= /home/suwayomi/.local/share/Tachidesk/webUI) -- Verifying WebUI files...
Could not load 'jcef' library
JCEF(43:37:856): initialized stderr logger, severity=LOGSEVERITY_DEFAULT
JCEF_I(43:37:856): CefApp: set state NEW
17:43:38.622 [main] INFO suwayomi.tachidesk.server.util.WebInterfaceManager isLocalWebUIValid(flavor= WebUI, path= /home/suwayomi/.local/share/Tachidesk/webUI) -- Validation succeeded - md5: local= f5c01a8ecc66b8b1f6f9d5314a7c956f; expected= f5c01a8ecc66b8b1f6f9d5314a7c956f
17:43:38.702 [main] INFO suwayomi.tachidesk.server.JavalinSetup -- Serving web static files for WebUI
17:43:39.969 [main] INFO io.javalin.Javalin -- Starting Javalin ...
```

Everything else is like normal.
When attempting to use a WebView, following exception is thrown:

```
java.lang.UnsatisfiedLinkError: 'org.cef.browser.CefRequestContext_N org.cef.browser.CefRequestContext_N.N_CreateContext(org.cef.handler.CefRequestContextHandler)'
	at org.cef.browser.CefRequestContext_N.N_CreateContext(Native Method)
	at org.cef.browser.CefRequestContext_N.createNative(CefRequestContext_N.java:39)
	at org.cef.browser.CefRequestContext.createContext(CefRequestContext.java:52)
	at xyz.nulldev.androidcompat.webkit.KcefWebViewProvider.createContext(KcefWebViewProvider.kt:1013)
	at xyz.nulldev.androidcompat.webkit.KcefWebViewProvider.createContext$default(KcefWebViewProvider.kt:1009)
	at xyz.nulldev.androidcompat.webkit.KcefWebViewProvider.loadUrl(KcefWebViewProvider.kt:487)
	at android.webkit.WebView.loadUrl(WebView.java:323)
	at eu.kanade.tachiyomi.extension.all.cubari.RemoteStorageUtils$GenericInterceptor.proceedWithWebView$lambda$2(Unknown Source)
	at eu.kanade.tachiyomi.extension.all.cubari.RemoteStorageUtils$GenericInterceptor.$r8$lambda$sxTRS6cXEU_gjgfLKSMupjd5_0Q(Unknown Source)
	at eu.kanade.tachiyomi.extension.all.cubari.RemoteStorageUtils$GenericInterceptor$$ExternalSyntheticLambda0.run(Unknown Source)
	at android.os.Handler.handleCallback(Handler.java:981)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:229)
	at android.os.Looper.loop(Looper.java:317)
	at suwayomi.tachidesk.server.LooperThread.run(ServerSetup.kt:89)
17:34:00.134 [Thread-0] INFO android.util.Log -- [ERROR] Looper: Loop handler threw
java.lang.NullPointerException: createContext(...) must not be null
	at xyz.nulldev.androidcompat.webkit.KcefWebViewProvider.createContext(KcefWebViewProvider.kt:1013)
	at xyz.nulldev.androidcompat.webkit.KcefWebViewProvider.createContext$default(KcefWebViewProvider.kt:1009)
	at xyz.nulldev.androidcompat.webkit.KcefWebViewProvider.loadUrl(KcefWebViewProvider.kt:487)
	at android.webkit.WebView.loadUrl(WebView.java:323)
	at eu.kanade.tachiyomi.extension.all.cubari.RemoteStorageUtils$GenericInterceptor.proceedWithWebView$lambda$2(Unknown Source)
	at eu.kanade.tachiyomi.extension.all.cubari.RemoteStorageUtils$GenericInterceptor.$r8$lambda$sxTRS6cXEU_gjgfLKSMupjd5_0Q(Unknown Source)
	at eu.kanade.tachiyomi.extension.all.cubari.RemoteStorageUtils$GenericInterceptor$$ExternalSyntheticLambda0.run(Unknown Source)
	at android.os.Handler.handleCallback(Handler.java:981)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:229)
	at android.os.Looper.loop(Looper.java:317)
	at suwayomi.tachidesk.server.LooperThread.run(ServerSetup.kt:89)
```

Since all extensions use WebView on a separate thread (MainLooper), they don't see this exception. Instead, they run into a timeout (on the latch), and deal with this like any other JS problem (e.g. "Timed out decrypting images").