### PR TITLE
Set HOME to avoid default "/"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,7 @@ RUN if command -v Xvfb; then \
       cp /usr/lib/jni/*.so ./; \
     fi
 
+ENV HOME=/home/suwayomi
 USER suwayomi
 EXPOSE 4567
 


### PR DESCRIPTION
`$HOME` is set to `/`, which is not writable, so it crashes. Setting it to default to suwayomi's home fixes the problem, and it's where we want to execute most things anyway

Closes #140