### PR TITLE
Fix koreaderSyncPercentageTolerance has type STRING rather than NUMBER

### DIFF
--- a/scripts/startup_script.sh
+++ b/scripts/startup_script.sh
@@ -113,7 +113,7 @@ sed -i -r "s/server.koreaderSyncUserkey = \"(.*?)\"( #)?/server.koreaderSyncUser
 sed -i -r "s/server.koreaderSyncDeviceId = \"(.*?)\"( #)?/server.koreaderSyncDeviceId = \"${KOREADER_SYNC_DEVICE_ID:-\1}\" #/" /home/suwayomi/.local/share/Tachidesk/server.conf
 sed -i -r "s/server.koreaderSyncChecksumMethod = \"(.*?)\"( #)?/server.koreaderSyncChecksumMethod = \"${KOREADER_SYNC_CHECKSUM_METHOD:-\1}\" #/" /home/suwayomi/.local/share/Tachidesk/server.conf
 sed -i -r "s/server.koreaderSyncStrategy = \"(.*?)\"( #)?/server.koreaderSyncStrategy = \"${KOREADER_SYNC_STRATEGY:-\1}\" #/" /home/suwayomi/.local/share/Tachidesk/server.conf
-sed -i -r "s/server.koreaderSyncPercentageTolerance = ([0-9\.]+|[a-zA-Z]+)?/server.koreaderSyncPercentageTolerance = \"${KOREADER_SYNC_PERCENTAGE_TOLERANCE:-\1}\" #/" /home/suwayomi/.local/share/Tachidesk/server.conf
+sed -i -r "s/server.koreaderSyncPercentageTolerance = ([0-9\.]+|[a-zA-Z]+)?/server.koreaderSyncPercentageTolerance = ${KOREADER_SYNC_PERCENTAGE_TOLERANCE:-\1} #/" /home/suwayomi/.local/share/Tachidesk/server.conf
 
 rm -rf /home/suwayomi/.local/share/Tachidesk/cache/kcef/Singleton*
 


### PR DESCRIPTION
If restart Docker Suwayomi Preview. The issue is caused by line 96 server.conf will become server.koreaderSyncPercentageTolerance = "0.0000000000001" instead of 0.00000000000001
WebUI output error

<img width="1694" height="917" alt="image" src="https://github.com/user-attachments/assets/b996fde4-4907-490c-b689-f244645ba4d5" />
