### PR TITLE
Specify absolute paths for copying libs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,8 @@ RUN userdel -r ubuntu && \
     mkdir -p /home/suwayomi/.local/share/Tachidesk && \
     if command -v Xvfb; then \
       mkdir /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix && \
-      cp /usr/lib/jni/libgluegen2_rt.so libgluegen_rt.so && \
-      cp /usr/lib/jni/*.so ./; \
+      cp /usr/lib/jni/libgluegen2_rt.so /home/suwayomi/libgluegen_rt.so && \
+      cp /usr/lib/jni/*.so /home/suwayomi/; \
     fi
 
 COPY scripts/create_server_conf.sh /home/suwayomi/create_server_conf.sh


### PR DESCRIPTION
Related to #191

However, that still doesn't solve the issue, now WebView loads but crashes with

```
*** stack smashing detected ***: terminated
*** stack smashing detected ***: terminated
```

```
17:46:07.490 [Thread-0] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: KcefWebViewProvider: initialize
17:46:07.508 [Thread-0] INFO suwayomi.tachidesk.server.ServerSetup -- Start loading cookies
17:46:07.518 [Thread-0] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Exposing: jsInterface.passPayload
Caught handled GLException: EGLGLXDrawableFactory - Could not initialize shared resources for EGLGraphicsDevice[type .egl, v0.0.0, nativeDisplayID 0x0, connection :99, unitID 0, handle 0x0, owner true, ResourceToolkitLock[obj 0x79244b9a, isOwner true, <7accce57, b7c5326>[count 1, qsz 0, owner <Thread-0-SharedResourceRunner>]]] on thread Thread-0-SharedResourceRunner
    [0]: jogamp.opengl.egl.EGLDrawableFactory$SharedResourceImplementation.createSharedResource(EGLDrawableFactory.java:555)
    [1]: jogamp.opengl.SharedResourceRunner.run(SharedResourceRunner.java:353)
    [2]: java.base/java.lang.Thread.run(Unknown Source)
Caused[0] by GLException: Failed to created/initialize EGL display incl. fallback default: native 0x0, error 0x3008/0x300c on thread Thread-0-SharedResourceRunner
    [0]: jogamp.opengl.egl.EGLDisplayUtil.eglGetDisplayAndInitialize(EGLDisplayUtil.java:381)
    [1]: jogamp.opengl.egl.EGLDisplayUtil.access$300(EGLDisplayUtil.java:61)
    [2]: jogamp.opengl.egl.EGLDisplayUtil$1.eglGetAndInitDisplay(EGLDisplayUtil.java:404)
    [3]: com.jogamp.nativewindow.egl.EGLGraphicsDevice.open(EGLGraphicsDevice.java:228)
    [4]: jogamp.opengl.egl.EGLDrawableFactory$SharedResourceImplementation.createEGLSharedResourceImpl(EGLDrawableFactory.java:569)
    [5]: jogamp.opengl.egl.EGLDrawableFactory$SharedResourceImplementation.createSharedResource(EGLDrawableFactory.java:553)
    [6]: jogamp.opengl.SharedResourceRunner.run(SharedResourceRunner.java:353)
    [7]: java.base/java.lang.Thread.run(Unknown Source)
Caught handled GLException: EGLGLXDrawableFactory - Could not initialize shared resources for X11GraphicsDevice[type .x11, connection :99, unitID 0, handle 0x0, owner false, ResourceToolkitLock[obj 0x5348a336, isOwner true, <3ba32af5, 5e05cf8f>[count 1, qsz 0, owner <Thread-0-SharedResourceRunner>]]] on thread Thread-0-SharedResourceRunner
    [0]: jogamp.opengl.egl.EGLDrawableFactory$SharedResourceImplementation.createSharedResource(EGLDrawableFactory.java:555)
    [1]: jogamp.opengl.SharedResourceRunner.run(SharedResourceRunner.java:353)
    [2]: java.base/java.lang.Thread.run(Unknown Source)
Caused[0] by GLException: Failed to created/initialize EGL display incl. fallback default: native 0x0, error 0x3008/0x300c on thread Thread-0-SharedResourceRunner
    [0]: jogamp.opengl.egl.EGLDisplayUtil.eglGetDisplayAndInitialize(EGLDisplayUtil.java:381)
    [1]: jogamp.opengl.egl.EGLDisplayUtil.access$300(EGLDisplayUtil.java:61)
    [2]: jogamp.opengl.egl.EGLDisplayUtil$1.eglGetAndInitDisplay(EGLDisplayUtil.java:404)
    [3]: com.jogamp.nativewindow.egl.EGLGraphicsDevice.open(EGLGraphicsDevice.java:228)
    [4]: jogamp.opengl.egl.EGLDrawableFactory$SharedResourceImplementation.createEGLSharedResourceImpl(EGLDrawableFactory.java:569)
    [5]: jogamp.opengl.egl.EGLDrawableFactory$SharedResourceImplementation.createSharedResource(EGLDrawableFactory.java:553)
    [6]: jogamp.opengl.SharedResourceRunner.run(SharedResourceRunner.java:353)
    [7]: java.base/java.lang.Thread.run(Unknown Source)
17:46:08.287 [Thread-0] INFO android.util.Log -- [DEBUG] KcefWebViewProvider: Page loaded from data at base URL https://kagane.org
17:46:08.312 [Thread-93] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Resource https://kagane.org/, result is cancel? false
17:46:08.471 [Thread-109] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Load start, pushing mappings
17:46:08.473 [Thread-120] INFO android.util.Log -- [DEBUG] KcefWebViewProvider: Navigate to https://kagane.org/
17:46:08.473 [Thread-123] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Status update: 
17:46:08.475 [Thread-132] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Resource https://kagane.org/_next/static/media/028c0d39d2e8f589-s.p.woff2, result is cancel? false
17:46:08.476 [Thread-134] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Resource https://kagane.org/_next/static/media/5b01f339abf2f1a5.p.woff2, result is cancel? false
17:46:08.476 [Thread-136] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Resource https://kagane.org/_next/static/css/25691a7999a57547.css, result is cancel? false
17:46:08.477 [Thread-138] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Resource https://kagane.org/_next/static/css/28af0ae5a93de9f4.css, result is cancel? false
17:46:08.477 [Thread-140] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Resource https://cland.fyi/770452e9/1.js, result is cancel? false
17:46:08.478 [Thread-142] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Resource https://kagane.org/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js, result is cancel? false
17:46:08.569 [Thread-176] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Resource https://kagane.org/_next/static/chunks/webpack-457a9c532676ae04.js, result is cancel? false
17:46:08.569 [Thread-178] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Resource https://kagane.org/_next/static/chunks/4bd1b696-ff1b509f0d6b7d09.js, result is cancel? false
17:46:08.570 [Thread-180] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Resource https://kagane.org/_next/static/chunks/vendors-8544afe8d75992d5.js, result is cancel? false
17:46:08.570 [Thread-182] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Resource https://kagane.org/_next/static/chunks/common-a885c087dabf77ea.js, result is cancel? false
17:46:08.571 [Thread-184] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Resource https://kagane.org/_next/static/chunks/main-app-afcc943daea11e6f.js, result is cancel? false
17:46:08.571 [Thread-188] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Resource https://kagane.org/_next/static/chunks/app/loading-527fad53dd983cd1.js, result is cancel? false
17:46:08.572 [Thread-192] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Resource https://kagane.org/_next/static/chunks/app/layout-8801b011cfe1d1f7.js, result is cancel? false
17:46:08.866 [Thread-228] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Resource https://kagane.org/_next/static/chunks/app/page-c4165f85493ebc99.js, result is cancel? false
17:46:08.901 [Thread-234] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Resource https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015, result is cancel? false
17:46:08.923 [Thread-239] INFO android.util.Log -- [DEBUG] KcefWebViewProvider: Navigate to https://kagane.org/
17:46:09.279 [Thread-254] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Load end https://kagane.org/
17:46:09.302 [Thread-265] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Resource https://kagane.org/cdn-cgi/rum?, result is cancel? false
17:46:09.427 [Thread-271] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Resource https://sophisticated-check.com/c/DB9I6xb.2P5Zl_SEW/QN9nNVj/YKwHMPTmUdw/M/in0/2pNhjOA_xON/TmA/zg, result is cancel? false
17:46:09.576 [Thread-280] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Resource https://kagane.org/favicons/favicon.ico, result is cancel? false
17:46:09.580 [Thread-294] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Resource https://kagane.org/search?_rsc=3lb4g, result is cancel? false
17:46:09.581 [Thread-296] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Resource https://kagane.org/reading?_rsc=3lb4g, result is cancel? false
17:46:09.582 [Thread-298] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Resource https://kagane.org/library?_rsc=3lb4g, result is cancel? false
17:46:09.582 [Thread-300] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Resource https://kagane.org/bookmarks?_rsc=3lb4g, result is cancel? false
17:46:09.649 [Thread-308] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Resource https://www.knobbyrefrigerator.pro/ecc874/c3c7fd67e9b1.js, result is cancel? false
17:46:09.650 [Thread-314] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Resource https://www.knobbyrefrigerator.pro/ecc874/c3c7fd67e9b1.js, result is cancel? false
17:46:09.674 [Thread-323] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Resource https://sophisticated-check.com/Yx2-xzpAZ.WB5C0_ZEGFFG0HY-TJ9KyLcMm_lOkPPQTRh-hTNUTVcW5_YYTZBajbY-mdZeifMgW_Yi2jYkTld-lnOoTpUq4_OsTtduhvN-2xIy2zMAT_lCmDZEDFI-3H, result is cancel? false
17:46:09.680 [Thread-338] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Resource https://kagane.org/favicons/favicon-32x32.png, result is cancel? false
[226:261:1016/174609.712108:ERROR:net/socket/ssl_client_socket_impl.cc:878] handshake failed; returned -1, SSL error code 1, net_error -100
*** stack smashing detected ***: terminated
17:46:17.484 [DefaultDispatcher-worker-10] ERROR suwayomi.tachidesk.graphql.AsDataFetcherResult -- asDataFetcherResult: failed due to
java.lang.Exception: Timed out getting drm challenge
	at eu.kanade.tachiyomi.extension.en.kagane.Kagane.getChallengeResponse(Unknown Source)
	at eu.kanade.tachiyomi.extension.en.kagane.Kagane.fetchPageList(Unknown Source)
	at eu.kanade.tachiyomi.source.online.HttpSource.getPageList$suspendImpl(HttpSource.kt:306)
	at eu.kanade.tachiyomi.source.online.HttpSource.getPageList(HttpSource.kt)
	at suwayomi.tachidesk.manga.impl.chapter.ChapterForDownload.fetchPageList(ChapterForDownload.kt:198)
	at suwayomi.tachidesk.manga.impl.chapter.ChapterForDownload.updateDownloadStatusAndPageList(ChapterForDownload.kt:157)
	at suwayomi.tachidesk.manga.impl.chapter.ChapterForDownload.asDownloadReady(ChapterForDownload.kt:86)
	at suwayomi.tachidesk.manga.impl.chapter.ChapterForDownloadKt.getChapterDownloadReady(ChapterForDownload.kt:40)
	at suwayomi.tachidesk.manga.impl.chapter.ChapterForDownloadKt.getChapterDownloadReady$default(ChapterForDownload.kt:34)
	at suwayomi.tachidesk.manga.impl.chapter.ChapterForDownloadKt.getChapterDownloadReadyById(ChapterForDownload.kt:43)
	at suwayomi.tachidesk.graphql.mutations.ChapterMutation$fetchChapterPages$1.invokeSuspend(ChapterMutation.kt:276)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:124)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:89)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:586)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:820)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:717)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:704)
JCEF_V(46:17:490): CefApp: client was disposed: org.cef.CefClient@78d4d200 [clients count 0]
*** stack smashing detected ***: terminated
*** stack smashing detected ***: terminated
```

Failing to load EGL is expected

May also be related to network issues on my side, since
```
17:46:09.680 [Thread-338] INFO android.util.Log -- [VERBOSE] KcefWebViewProvider: Resource https://kagane.org/favicons/favicon-32x32.png, result is cancel? false
[226:261:1016/174609.712108:ERROR:net/socket/ssl_client_socket_impl.cc:878] handshake failed; returned -1, SSL error code 1, net_error -100
```

still, it's worth to investigate where stack smashing is coming from