### PR TITLE
Add `init` to flaresolverr

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
   flaresolverr:
     image: ghcr.io/thephaseless/byparr:latest
     container_name: flaresolverr
+    init: true
     environment:
       - TZ=Etc/UTC # Use TZ database name from https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     restart: unless-stopped


### PR DESCRIPTION
See https://github.com/ThePhaseless/Byparr/commit/9334169265c43a30fd354b18c4c86ccce7157526

Without it, I consistently see zombies every 15 minutes:

```
constan+    3337    2368  0 09:42 ?        00:00:01 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+    3354    2368  0 09:42 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+    3388    2368  0 09:42 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+    3705    2368  0 09:56 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+    4169    2368  0 10:11 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+    4467    2368  0 10:26 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+    5104    2368  0 10:41 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+    5792    2368  0 10:56 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+    6386    2368  0 11:11 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+    7012    2368  0 11:26 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+    7361    2368  0 11:41 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+    7642    2368  0 11:56 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+    7946    2368  0 12:11 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+    8256    2368  0 12:26 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+    8572    2368  0 12:41 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+    8868    2368  0 12:56 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+    9210    2368  0 13:11 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+    9579    2368  0 13:26 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+    9881    2368  0 13:41 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+   10155    2368  0 13:56 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+   10457    2368  0 14:11 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+   10799    2368  0 14:26 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+   11128    2368  0 14:41 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+   11411    2368  0 14:56 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+   11709    2368  0 15:11 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+   12014    2368  0 15:26 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+   12306    2368  0 15:41 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+   12636    2368  0 15:56 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+   12942    2368  0 16:11 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+   13271    2368  0 16:26 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+   13628    2368  0 16:41 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+   13931    2368  0 16:56 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+   14311    2368  0 17:11 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+   14623    2368  0 17:26 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+   14946    2368  0 17:41 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+   15299    2368  0 17:56 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+   15617    2368  0 18:11 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+   15980    2368  0 18:26 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+   16288    2368  0 18:41 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
constan+   16743    2368  0 18:56 ?        00:00:00 /app/.venv/lib/python3.14/site-packages/playwright/driver/node /app/.venv/lib/python3.14/site-packages/playwright/driver/package/cli.js run-driver
```

<strike>@Robonau you may want to see if the converter also requires this, I've seen zombies there was well, but may also be a stuck conversion? (in case it wasn't clear, it's using 11% of my ram and 8% CPU, for ~10 hours, of which 1 hour is active CPU time)</strike> different issue
```
constan+    1721  8.8 11.0 74823324 871432 ?     Ssl  09:41  51:04 bun run index.ts
```