### PR TITLE
Add support for passwords in _FILE var

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Use the template [docker-compose.yml](./docker-compose.yml) in this repo for cre
 > [!Tip]
 > Most of the time you don't need to use environment variables, instead settings can be changed during runtime via the webUI. (which will be rendered useless when providing an environment variable)
 
+> [!Tip]
+> Passwords can be provided as files, by appending `_FILE` to the variable name. FOr example, you can set `SOCKS_PROXY_PASSWORD_FILE=/path/to/myfile` to have Suwayomi set the socks proxy password using "myfile" content.
+
 > [!NOTE]
 > See [server-reference.conf](https://github.com/Suwayomi/Suwayomi-Server/blob/master/server/src/main/resources/server-reference.conf) in the [Suwayomi-Server](https://github.com/Suwayomi/Suwayomi-Server) repository for the default values
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Use the template [docker-compose.yml](./docker-compose.yml) in this repo for cre
 > Most of the time you don't need to use environment variables, instead settings can be changed during runtime via the webUI. (which will be rendered useless when providing an environment variable)
 
 > [!Tip]
-> Passwords can be provided as files, by appending `_FILE` to the variable name. FOr example, you can set `SOCKS_PROXY_PASSWORD_FILE=/path/to/myfile` to have Suwayomi set the socks proxy password using "myfile" content.
+> Passwords can be provided as files, by appending `_FILE` to the variable name. For example, you can set `SOCKS_PROXY_PASSWORD_FILE=/path/to/myfile` to have Suwayomi use the content of "myfile" as socks proxy password.
 
 > [!NOTE]
 > See [server-reference.conf](https://github.com/Suwayomi/Suwayomi-Server/blob/master/server/src/main/resources/server-reference.conf) in the [Suwayomi-Server](https://github.com/Suwayomi/Suwayomi-Server) repository for the default values

--- a/scripts/startup_script.sh
+++ b/scripts/startup_script.sh
@@ -11,6 +11,21 @@ echo "Suwayomi data location inside the container: /home/suwayomi/.local/share/T
 # set default values for environment variables:
 export TZ="${TZ:-Etc/UTC}"
 
+# Getting passwords from files
+if [ -f "${SOCKS_PROXY_PASSWORD_FILE}" ]; then
+    export SOCKS_PROXY_PASSWORD=$(cat "${SOCKS_PROXY_PASSWORD_FILE}")
+fi
+if [ -f "${AUTH_PASSWORD_FILE}" ]; then
+    export AUTH_PASSWORD=$(cat "${AUTH_PASSWORD_FILE}")
+fi
+if [ -f "${BASIC_AUTH_PASSWORD_FILE}" ]; then
+    export BASIC_AUTH_PASSWORD=$(cat "${BASIC_AUTH_PASSWORD_FILE}")
+fi
+if [ -f "${DATABASE_PASSWORD_FILE}" ]; then
+    export DATABASE_PASSWORD=$(cat "${DATABSE_PASSWORD_FILE}")
+fi
+
+
 # Set default values for settings
 sed -i -r "s/server.initialOpenInBrowserEnabled = ([0-9]+|[a-zA-Z]+)( #)?/server.initialOpenInBrowserEnabled = false #/" /home/suwayomi/.local/share/Tachidesk/server.conf
 sed -i -r "s/server.systemTrayEnabled = ([0-9]+|[a-zA-Z]+)( #)?/server.systemTrayEnabled = false #/" /home/suwayomi/.local/share/Tachidesk/server.conf


### PR DESCRIPTION
Add `*_FILE` variable for each `*_PASSWORD` environment variable.
If a `*_FILE` variable is specified, the linked variable will be filled with the file content.

It allows using docker secrets, and prevent showing sensible data in docker inspect.
This is a feature that is pretty common on a lot of image (like on postgresql docker image).