### PR TITLE
Remove `init` on flaresolverr container

### DIFF
--- a/docker-compose-postgresql.yml
+++ b/docker-compose-postgresql.yml
@@ -63,7 +63,6 @@ services:
   flaresolverr:
     image: ghcr.io/thephaseless/byparr:latest
     container_name: flaresolverr
-    init: true
     environment:
       - TZ=${TZ:-Etc/UTC}
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,6 @@ services:
   flaresolverr:
     image: ghcr.io/thephaseless/byparr:latest
     container_name: flaresolverr
-    init: true
     environment:
       - TZ=Etc/UTC # Use TZ database name from https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     restart: unless-stopped


### PR DESCRIPTION
Since ThePhaseless/Byparr@b177dc6ad4488a9112ccd91e140fc7f32275b64c (v3.0.0), Byparr uses `tini` as init system, so `init` is not required anymore; flaresolverr never needed it

Reported on discord